### PR TITLE
labs instead of abs

### DIFF
--- a/tests/termination_test.c
+++ b/tests/termination_test.c
@@ -156,7 +156,7 @@ init_term_test (int converter, double src_ratio)
 		exit (1) ;
 		} ;
 
-	if (abs (src_data.input_frames_used - input_len) > 1)
+	if (labs (src_data.input_frames_used - input_len) > 1)
 	{	printf ("\n\nLine %d : input_frames_used should be %d, is %ld.\n\n",
 					 __LINE__, input_len, src_data.input_frames_used) ;
 		printf ("\tsrc_ratio  : %.4f\n", src_ratio) ;


### PR DESCRIPTION
When trying to build the lib on my mac, I got the error from the gcc
to use labs instead of abs.

I'm not strong in C, so does this make sense?

At least it was building the lib then...