### PR TITLE
Fix configuration with MinGW under Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+*.ac text eol=lf
+*.am text eol=lf
+*.m4 text eol=lf
+*.pc text eol=lf
+*.spec text eol=lf
+*.sh text eol=lf
+
+*.bat text eol=crlf
+*.def text eol=crlf
+*.msvc text eol=crlf


### PR DESCRIPTION
Running `./autogen.sh` with MinGW and Windows fails:

    $ ./autogen.sh
    checking for autoconf...
    checking for automake... yes
    checking for libtool... libtoolize
    I am going to run ./configure with no arguments - if you wish
    to pass any to it, please specify them on the ./autogen.sh command line.
    Generating configuration files for libsamplerate, please wait....
    aclocal -I M4
    ' is already registered with AC_CONFIG_FILES.
    ../../lib/autoconf/status.m4:288: AC_CONFIG_FILES is expanded from...
    configure.ac:312: the top level
    autom4te: /usr/bin/m4 failed with exit status: 1
    aclocal-1.15: error: echo failed with exit status: 1

This error happens because Git sets `CRLF` line endings under Windows in all files by default, but Autotools wants Linux-style `LF` line endings in its scripts.

This PR adds `.gitattributes` file and now Git will set proper `LF` line endings for Autotools scripts. Also some files were normalized and now have proper line endings (Windows makefiles etc).