### PR TITLE
Declare AUDIO_OUT once and in audio_out.h

### DIFF
--- a/examples/audio_out.c
+++ b/examples/audio_out.c
@@ -33,11 +33,6 @@
 #define MAKE_MAGIC(a,b,c,d,e,f,g,h)		\
 			((a) + ((b) << 1) + ((c) << 2) + ((d) << 3) + ((e) << 4) + ((f) << 5) + ((g) << 6) + ((h) << 7))
 
-typedef	struct AUDIO_OUT_s
-{	int magic ;
-} AUDIO_OUT ;
-
-
 /*------------------------------------------------------------------------------
 **	Linux (ALSA and OSS) functions for playing a sound.
 */


### PR DESCRIPTION
Silences redefinition errors on some compilers
GCC 4.5.3 for some reason is more loud than other versions.
[Build log](http://nyftp.netbsd.org/pub/pkgsrc/packages/reports/2017Q1/NetBSD-6.0-i386/20170423.1108/libsamplerate-0.1.9/build.log)