### PR TITLE
Remove dead assignment

### DIFF
--- a/src/src_sinc.c
+++ b/src/src_sinc.c
@@ -343,7 +343,6 @@ sinc_mono_vari_process (SRC_PRIVATE *psrc, SRC_DATA *data)
 	half_filter_chan_len = filter->channels * (lrint (count) + 1) ;
 
 	input_index = psrc->last_position ;
-	float_increment = filter->index_inc ;
 
 	rem = fmod_one (input_index) ;
 	filter->b_current = (filter->b_current + filter->channels * lrint (input_index - rem)) % filter->b_len ;
@@ -492,7 +491,6 @@ sinc_stereo_vari_process (SRC_PRIVATE *psrc, SRC_DATA *data)
 	half_filter_chan_len = filter->channels * (lrint (count) + 1) ;
 
 	input_index = psrc->last_position ;
-	float_increment = filter->index_inc ;
 
 	rem = fmod_one (input_index) ;
 	filter->b_current = (filter->b_current + filter->channels * lrint (input_index - rem)) % filter->b_len ;
@@ -646,7 +644,6 @@ sinc_quad_vari_process (SRC_PRIVATE *psrc, SRC_DATA *data)
 	half_filter_chan_len = filter->channels * (lrint (count) + 1) ;
 
 	input_index = psrc->last_position ;
-	float_increment = filter->index_inc ;
 
 	rem = fmod_one (input_index) ;
 	filter->b_current = (filter->b_current + filter->channels * lrint (input_index - rem)) % filter->b_len ;
@@ -806,7 +803,6 @@ sinc_hex_vari_process (SRC_PRIVATE *psrc, SRC_DATA *data)
 	half_filter_chan_len = filter->channels * (lrint (count) + 1) ;
 
 	input_index = psrc->last_position ;
-	float_increment = filter->index_inc ;
 
 	rem = fmod_one (input_index) ;
 	filter->b_current = (filter->b_current + filter->channels * lrint (input_index - rem)) % filter->b_len ;
@@ -1053,7 +1049,6 @@ sinc_multichan_vari_process (SRC_PRIVATE *psrc, SRC_DATA *data)
 	half_filter_chan_len = filter->channels * (lrint (count) + 1) ;
 
 	input_index = psrc->last_position ;
-	float_increment = filter->index_inc ;
 
 	rem = fmod_one (input_index) ;
 	filter->b_current = (filter->b_current + filter->channels * lrint (input_index - rem)) % filter->b_len ;


### PR DESCRIPTION
I threw clang static analyzer at the code
float_increment is assigned again before it is used, making the initial assignment redundant.