### PR TITLE
Don't make AUDIO_OUT an opaque type

### DIFF
--- a/examples/audio_out.h
+++ b/examples/audio_out.h
@@ -6,7 +6,9 @@
 ** file at : https://github.com/erikd/libsamplerate/blob/master/COPYING
 */
 
-typedef	struct AUDIO_OUT_s AUDIO_OUT ;
+typedef	struct AUDIO_OUT_s
+{	int magic ;
+} AUDIO_OUT ;
 
 typedef int (*get_audio_callback_t) (void *callback_data, float *samples, int frames) ;
 


### PR DESCRIPTION
The linux ALSA code is using its members
Issue #15