### PR TITLE
add Watcom versions of lrint and lrintf asm inlines

### DIFF
--- a/src/float_cast.h
+++ b/src/float_cast.h
@@ -63,6 +63,37 @@
 
 	#include	<math.h>
 
+#elif (defined (__WATCOMC__) && defined(__386__))
+
+	#include	<math.h>
+
+	#undef		HAVE_LRINT_REPLACEMENT
+	#define		HAVE_LRINT_REPLACEMENT	1
+
+	#undef	lrint
+	#undef	lrintf
+
+	#define	lrint	double2int
+	#define	lrintf	float2int
+
+extern __inline long double2int(double);
+#pragma aux double2int = \
+    "push  eax" \
+    "fistp dword ptr [esp]" \
+    "pop   eax" \
+    parm [8087] \
+    value [eax] \
+    modify exact [eax];
+
+extern __inline long float2int(float);
+#pragma aux float2int = \
+    "push  eax" \
+    "fistp dword ptr [esp]" \
+    "pop   eax" \
+    parm [8087] \
+    value [eax] \
+    modify exact [eax];
+
 #elif (defined (__CYGWIN__))
 
 	#include	<math.h>


### PR DESCRIPTION
This changeset adds lrint() and lrintf() 386 asm inlines for Watcom compiler.