### PR TITLE
drop comma at end of enumerator

### DIFF
--- a/src/samplerate.h
+++ b/src/samplerate.h
@@ -166,7 +166,7 @@ enum
 	SRC_SINC_MEDIUM_QUALITY		= 1,
 	SRC_SINC_FASTEST			= 2,
 	SRC_ZERO_ORDER_HOLD			= 3,
-	SRC_LINEAR					= 4,
+	SRC_LINEAR					= 4
 } ;
 
 /*


### PR DESCRIPTION
Some older compilers might still choke on this with -pedantic.
And it saves a patchfile downstream.