### PR TITLE
BSD lincensed now

### DIFF
--- a/libsamplerate.spec.in
+++ b/libsamplerate.spec.in
@@ -9,7 +9,7 @@ Name: %{name}
 Version: %{version}
 Release: %{release}
 Prefix: %{prefix}
-Copyright: LGPL
+Copyright: BSD
 Group: Libraries/Sound
 Source: http://www.mega-nerd.com/SRC/libsamplerate-%{version}.tar.gz
 URL: http://www.mega-nerd.com/SRC/


### PR DESCRIPTION
Libsamplerate is BSD licensed since 2016.
(So we should get rid of the GNU auto* cruft :-)
