### PR TITLE
Make libsamplerate work with other libs/frameworks such as JUCE.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ include(CheckSymbolExists)
 include(CheckTypeSize)
 include(CMakePushCheckState)
 include(ClipMode)
+add_definitions(-DHAVE_CONFIG_H)
 
 set(SAMPLERATE_SRC
 	${PROJECT_SOURCE_DIR}/src/samplerate.c

--- a/Makefile.am
+++ b/Makefile.am
@@ -27,7 +27,8 @@ CLEANFILES = src/src_sinc.s
 # MinGW requires -no-undefined if a DLL is to be built.
 src_libsamplerate_la_LDFLAGS = -no-undefined -version-info $(SHARED_VERSION_INFO) $(SHLIB_VERSION_ARG)
 src_libsamplerate_la_SOURCES = src/samplerate.c src/src_sinc.c src/src_zoh.c src/src_linear.c \
-	src/common.h src/float_cast.h src/fastest_coeffs.h src/mid_qual_coeffs.h src/high_qual_coeffs.h
+	src/common.h src/float_cast.h src/fastest_coeffs.h src/mid_qual_coeffs.h src/high_qual_coeffs.h \
+	src/src_config.h
 
 #-------------------------------------------------------------------------------
 # An extra check for bad asm.

--- a/configure.ac
+++ b/configure.ac
@@ -223,7 +223,7 @@ dnl ============================================================================
 dnl  Compiler stuff.
 
 AS_IF([test "x$enable_flags_setting" = "xyes"], [
-		AX_APPEND_COMPILE_FLAGS([-O2 -pipe], [CFLAGS])
+		AX_APPEND_COMPILE_FLAGS([-DHAVE_CONFIG_H -O2 -pipe], [CFLAGS])
 
 		AS_CASE([${host_os}],
 			[darwin*], [

--- a/examples/audio_out.c
+++ b/examples/audio_out.c
@@ -11,7 +11,7 @@
 #include <string.h>
 #include <unistd.h>
 
-#include <config.h>
+#include "src_config.h"
 
 #include "audio_out.h"
 

--- a/examples/timewarp-file.c
+++ b/examples/timewarp-file.c
@@ -6,7 +6,7 @@
 ** file at : https://github.com/erikd/libsamplerate/blob/master/COPYING
 */
 
-#include "config.h"
+#include "src_config.h"
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/examples/varispeed-play.c
+++ b/examples/varispeed-play.c
@@ -11,7 +11,7 @@
 #include <unistd.h>
 #include <string.h>
 
-#include "config.h"
+#include "src_config.h"
 
 #include <float_cast.h>
 

--- a/src/common.h
+++ b/src/common.h
@@ -33,6 +33,15 @@ typedef	long	int32_t ;
 #define	MAKE_MAGIC(a,b,c,d,e,f)	((a) + ((b) << 4) + ((c) << 8) + ((d) << 12) + ((e) << 16) + ((f) << 20))
 
 /*
+** Adds casting needed if compiled/included within cpp
+*/
+#ifdef __cplusplus
+#define ZERO_ALLOC(type, size)	static_cast<type*>(calloc(1, size))
+#else // __cplusplus
+#define ZERO_ALLOC(type, size)	calloc(1, size)
+#endif
+
+/*
 ** Inspiration : http://sourcefrog.net/weblog/software/languages/C/unused.html
 */
 #ifdef UNUSED

--- a/src/float_cast.h
+++ b/src/float_cast.h
@@ -35,7 +35,7 @@
 **		long int lrint  (double x) ;
 */
 
-#include "config.h"
+#include "src_config.h"
 
 /*
 **	The presence of the required functions are detected during the configure

--- a/src/samplerate.c
+++ b/src/samplerate.c
@@ -10,7 +10,7 @@
 #include	<stdlib.h>
 #include	<string.h>
 
-#include	"config.h"
+#include	"src_config.h"
 
 #include	"samplerate.h"
 #include	"float_cast.h"

--- a/src/samplerate.c
+++ b/src/samplerate.c
@@ -32,7 +32,7 @@ src_new (int converter_type, int channels, int *error)
 		return NULL ;
 		} ;
 
-	if ((psrc = calloc (1, sizeof (*psrc))) == NULL)
+	if ((psrc = ZERO_ALLOC (SRC_PRIVATE, sizeof (*psrc))) == NULL)
 	{	if (error)
 			*error = SRC_ERR_MALLOC_FAILED ;
 		return NULL ;
@@ -62,7 +62,7 @@ src_clone (SRC_STATE* orig, int *error)
 	if (error)
 		*error = SRC_ERR_NO_ERROR ;
 
-	if ((psrc = calloc (1, sizeof (*psrc))) == NULL)
+	if ((psrc = ZERO_ALLOC (SRC_PRIVATE, sizeof (*psrc))) == NULL)
 	{	if (error)
 			*error = SRC_ERR_MALLOC_FAILED ;
 		return NULL ;

--- a/src/src_config.h
+++ b/src/src_config.h
@@ -1,0 +1,12 @@
+/*
+** Copyright (c) 1999-2016, Erik de Castro Lopo <erikd@mega-nerd.com>
+** All rights reserved.
+**
+** This code is released under 2-clause BSD license. Please see the
+** file at : https://github.com/erikd/libsamplerate/blob/master/COPYING
+*/
+
+// allow config.h to be optional
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif

--- a/src/src_linear.c
+++ b/src/src_linear.c
@@ -171,7 +171,7 @@ linear_set_converter (SRC_PRIVATE *psrc, int src_enum)
 		} ;
 
 	if (psrc->private_data == NULL)
-	{	priv = calloc (1, sizeof (*priv) + psrc->channels * sizeof (float)) ;
+	{	priv = ZERO_ALLOC (LINEAR_DATA, sizeof (*priv) + psrc->channels * sizeof (float)) ;
 		psrc->private_data = priv ;
 		} ;
 
@@ -219,7 +219,7 @@ linear_copy (SRC_PRIVATE *from, SRC_PRIVATE *to)
 	LINEAR_DATA* from_priv = (LINEAR_DATA*) from->private_data ;
 	size_t private_size = sizeof (*to_priv) + from_priv->channels * sizeof (float) ;
 
-	if ((to_priv = calloc (1, private_size)) == NULL)
+	if ((to_priv = ZERO_ALLOC (LINEAR_DATA, private_size)) == NULL)
 		return SRC_ERR_MALLOC_FAILED ;
 
 	memcpy (to_priv, from_priv, private_size) ;

--- a/src/src_linear.c
+++ b/src/src_linear.c
@@ -10,7 +10,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "config.h"
+#include "src_config.h"
 #include "float_cast.h"
 #include "common.h"
 

--- a/src/src_sinc.c
+++ b/src/src_sinc.c
@@ -216,7 +216,7 @@ sinc_set_converter (SRC_PRIVATE *psrc, int src_enum)
 	temp_filter.b_len = MAX (temp_filter.b_len, 4096) ;
 	temp_filter.b_len *= temp_filter.channels ;
 
-	if ((filter = calloc (1, sizeof (SINC_FILTER) + sizeof (filter->buffer [0]) * (temp_filter.b_len + temp_filter.channels))) == NULL)
+	if ((filter = ZERO_ALLOC (SINC_FILTER, sizeof (SINC_FILTER) + sizeof (filter->buffer [0]) * (temp_filter.b_len + temp_filter.channels))) == NULL)
 		return SRC_ERR_MALLOC_FAILED ;
 
 	*filter = temp_filter ;
@@ -265,7 +265,7 @@ sinc_copy (SRC_PRIVATE *from, SRC_PRIVATE *to)
 	SINC_FILTER* from_filter = (SINC_FILTER*) from->private_data ;
 	size_t private_length = sizeof (SINC_FILTER) + sizeof (from_filter->buffer [0]) * (from_filter->b_len + from_filter->channels) ;
 
-	if ((to_filter = calloc (1, private_length)) == NULL)
+	if ((to_filter = ZERO_ALLOC (SINC_FILTER, private_length)) == NULL)
 		return SRC_ERR_MALLOC_FAILED ;
 
 	memcpy (to_filter, from_filter, private_length) ;

--- a/src/src_sinc.c
+++ b/src/src_sinc.c
@@ -10,7 +10,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "config.h"
+#include "src_config.h"
 #include "float_cast.h"
 #include "common.h"
 

--- a/src/src_zoh.c
+++ b/src/src_zoh.c
@@ -162,7 +162,7 @@ zoh_set_converter (SRC_PRIVATE *psrc, int src_enum)
 		} ;
 
 	if (psrc->private_data == NULL)
-	{	priv = calloc (1, sizeof (*priv) + psrc->channels * sizeof (float)) ;
+	{	priv = ZERO_ALLOC (ZOH_DATA, sizeof (*priv) + psrc->channels * sizeof (float)) ;
 		psrc->private_data = priv ;
 		} ;
 
@@ -210,7 +210,7 @@ zoh_copy (SRC_PRIVATE *from, SRC_PRIVATE *to)
 	ZOH_DATA* from_priv = (ZOH_DATA*) from->private_data ;
 	size_t private_size = sizeof (*to_priv) + from_priv->channels * sizeof (float) ;
 
-	if ((to_priv = calloc (1, private_size)) == NULL)
+	if ((to_priv = ZERO_ALLOC (ZOH_DATA, private_size)) == NULL)
 		return SRC_ERR_MALLOC_FAILED ;
 
 	memcpy (to_priv, from_priv, private_size) ;

--- a/src/src_zoh.c
+++ b/src/src_zoh.c
@@ -10,7 +10,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "config.h"
+#include "src_config.h"
 #include "float_cast.h"
 #include "common.h"
 

--- a/tests/calc_snr.c
+++ b/tests/calc_snr.c
@@ -6,7 +6,7 @@
 ** file at : https://github.com/erikd/libsamplerate/blob/master/COPYING
 */
 
-#include "config.h"
+#include "src_config.h"
 
 #include "util.h"
 

--- a/tests/callback_hang_test.c
+++ b/tests/callback_hang_test.c
@@ -6,7 +6,7 @@
 ** file at : https://github.com/erikd/libsamplerate/blob/master/COPYING
 */
 
-#include "config.h"
+#include "src_config.h"
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/tests/multi_channel_test.c
+++ b/tests/multi_channel_test.c
@@ -6,7 +6,7 @@
 ** file at : https://github.com/erikd/libsamplerate/blob/master/COPYING
 */
 
-#include "config.h"
+#include "src_config.h"
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/tests/multichan_throughput_test.c
+++ b/tests/multichan_throughput_test.c
@@ -14,7 +14,7 @@
 
 #include <samplerate.h>
 
-#include "config.h"
+#include "src_config.h"
 
 #include "util.h"
 #include "float_cast.h"

--- a/tests/snr_bw_test.c
+++ b/tests/snr_bw_test.c
@@ -6,7 +6,7 @@
 ** file at : https://github.com/erikd/libsamplerate/blob/master/COPYING
 */
 
-#include "config.h"
+#include "src_config.h"
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/tests/src-evaluate.c
+++ b/tests/src-evaluate.c
@@ -12,7 +12,7 @@
 #include <string.h>
 #include <ctype.h>
 
-#include "config.h"
+#include "src_config.h"
 
 #if (HAVE_FFTW3 && HAVE_SNDFILE && HAVE_SYS_TIMES_H)
 

--- a/tests/throughput_test.c
+++ b/tests/throughput_test.c
@@ -14,7 +14,7 @@
 
 #include <samplerate.h>
 
-#include "config.h"
+#include "src_config.h"
 
 #include "util.h"
 #include "float_cast.h"

--- a/tests/util.h
+++ b/tests/util.h
@@ -6,7 +6,7 @@
 ** file at : https://github.com/erikd/libsamplerate/blob/master/COPYING
 */
 
-#include "config.h"
+#include "src_config.h"
 
 #define	ABS(a)			(((a) < 0) ? - (a) : (a))
 #define MIN(a,b)		(((a) < (b)) ? (a) : (b))

--- a/tests/varispeed_test.c
+++ b/tests/varispeed_test.c
@@ -6,7 +6,7 @@
 ** file at : https://github.com/erikd/libsamplerate/blob/master/COPYING
 */
 
-#include "config.h"
+#include "src_config.h"
 
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
I'm going to make libsamplerate as a [JUCE](https://github.com/WeAreROLI/JUCE) [module](https://github.com/WeAreROLI/JUCE/blob/master/modules/JUCE%20Module%20Format.txt).

I've made minor "cosmetic" changes that will be very welcomed to keep using the libsamplerate origin git as a submodule of this module.

Explained are the 2 commits:

- Allow compilation under cpp:
   - calloc/malloc in cpp won't compile without casting. sadly due to the JUCE module workflow you need to include 'samplerate.c' in a .cpp file..

- HAVE_CONFIG_H
  - Also without JUCE, if you just link to the library (especially now when it's very open-sourced - thank you!) the generating of 'config.h' just to add it to your code can be tricky and also when not made carefully could conflict with other `config.h`. with the JUCE module for example I generate all the defs with macros that are already exists in JUCE itself. here is an example of such use.
https://github.com/WeAreROLI/JUCE/blob/master/modules/juce_audio_formats/codecs/juce_FlacAudioFormat.cpp


