### PR TITLE
Fix for src-evaluate

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -157,10 +157,6 @@ tests_multichan_throughput_test_SOURCES = tests/multichan_throughput_test.c test
 tests_multichan_throughput_test_CFLAGS = $(FFTW3_CFLAGS)
 tests_multichan_throughput_test_LDADD = src/libsamplerate.la $(FFTW3_LIBS)
 
-if HAVE_LIBSNDFILE
-check_PROGRAMS += tests/src-evaluate
-
 tests_src_evaluate_SOURCES = tests/src-evaluate.c tests/calc_snr.c tests/util.c
 tests_src_evaluate_CFLAGS = $(SNDFILE_CFLAGS) $(FFTW3_CFLAGS)
 tests_src_evaluate_LDADD = $(SNDFILE_LIBS) $(FFTW3_LIBS)
-endif


### PR DESCRIPTION
2 parts:

1. As described in https://github.com/erikd/libsamplerate/pull/69#discussion_r306719029 src-evaluate does compile without libsndfile. Currently the build fails if it isn't found as src-evaluate is added to the required binaries. This is fixed, as it is now always build which is consistent with how the rest of the tests/examples handle the missing dependencies
2. Add the target to CMake to have consistent results in both build systems

- [x] Requires #75