### PR TITLE
src_float_to_short_array: Use division instead of shift

### DIFF
--- a/src/samplerate.c
+++ b/src/samplerate.c
@@ -510,7 +510,7 @@ src_float_to_short_array (const float *in, short *out, int len)
 			continue ;
 			} ;
 
-		out [len] = (short) (lrint (scaled_value) >> 16) ;
+		out [len] = (short) (lrint (scaled_value) / 0x10000) ;
 		} ;
 
 } /* src_float_to_short_array */


### PR DESCRIPTION
@janstary I wonder if this fixes your issue on PowerPC.