### PR TITLE
 Add test shwoing memory corruption when using src_set_ratio

### DIFF
--- a/tests/util.h
+++ b/tests/util.h
@@ -29,6 +29,19 @@ double calculate_snr (float *data, int len, int expected_peaks) ;
 
 const char * get_cpu_name (void) ;
 
+/** Assertions for tests */
+#define CHECKED_CALL(call) \
+	if ((error = call)) \
+	{	printf ("\n\nSRC call failed on Line %d : %s -> %s\n\n", __LINE__, #call, src_strerror (error)) ; \
+		exit (1) ; \
+	}
+
+#define TEST(condition) \
+	if (!(condition)) \
+	{	printf ("Condition failed on Line %d : %s\n\n", __LINE__, #condition) ; \
+		exit (1) ; \
+	}
+
 #if OS_IS_WIN32
 /*
 **	Extra Win32 hacks.

--- a/tests/varispeed_test.c
+++ b/tests/varispeed_test.c
@@ -26,10 +26,14 @@
 #define	BUFFER_LEN		(1 << 16)
 
 static void varispeed_test (int converter, double target_snr) ;
+static void set_ratio_test (int converter, int channels, double initial_ratio, double second_ratio) ;
 
 int
 main (void)
 {
+	int CONVERTERS[] = {SRC_SINC_FASTEST, SRC_ZERO_ORDER_HOLD, SRC_LINEAR};
+	double RATIOS[] = {0.1, 0.01, 20};//{1./256., .01, 1.1, 256};
+
 	puts ("") ;
 	printf ("    Zero Order Hold interpolator    : ") ;
 	varispeed_test (SRC_ZERO_ORDER_HOLD, 10.0) ;
@@ -39,6 +43,15 @@ main (void)
 
 	printf ("    Sinc interpolator               : ") ;
 	varispeed_test (SRC_SINC_FASTEST, 115.0) ;
+
+	for(int i = 0; i < ARRAY_LEN(CONVERTERS); i++)
+		for(int channels=1; channels <=16; channels*=2)
+			for(int iFirst=0; iFirst < ARRAY_LEN(RATIOS); iFirst++)
+				for(int iSecond=0; iSecond < ARRAY_LEN(RATIOS); iSecond++)
+				{
+					if(iFirst != iSecond)
+						set_ratio_test(CONVERTERS[i], channels, RATIOS[iFirst], RATIOS[iSecond]);
+				}
 
 	fftw_cleanup () ;
 	puts ("") ;
@@ -149,3 +162,89 @@ varispeed_test (int converter, double target_snr)
 	return ;
 } /* varispeed_test */
 
+static void adjustData(SRC_DATA *statistic, SRC_DATA *curData, int channels)
+{
+	TEST(curData->input_frames_used <= statistic->input_frames);
+	TEST(curData->output_frames_gen <= statistic->output_frames);
+
+	statistic->input_frames_used += curData->input_frames_used;
+	statistic->output_frames_gen += curData->output_frames_gen;
+	curData->input_frames -= curData->input_frames_used;
+	curData->data_in += curData->input_frames_used * channels;
+	curData->output_frames -= curData->output_frames_gen;
+	curData->data_out += curData->output_frames_gen * channels;
+}
+
+static void
+set_ratio_test (int converter, int channels, double initial_ratio, double second_ratio)
+{
+	printf("set_ratio_test(converter=%d, channels=%d, initial ratio=%g, 2nd ratio=%g)\n",
+		converter, channels, initial_ratio, second_ratio);
+
+	const int NUM_FRAMES = 40*256;
+	const int CHUNK_SIZE = 128;
+	
+	float *input = calloc(NUM_FRAMES * channels, sizeof(float));
+	TEST(input);
+	float *output = calloc(NUM_FRAMES * channels, sizeof(float));
+	TEST(output);
+	float *tmpBuffer = calloc(NUM_FRAMES * channels, sizeof(float));
+	TEST(tmpBuffer);
+
+	SRC_DATA data, curData;
+	memset (&data, 0, sizeof (data));
+	data.data_in = input;
+	data.data_out = output;
+	data.input_frames = NUM_FRAMES;
+	data.output_frames = NUM_FRAMES;
+	data.end_of_input = 0;
+	data.src_ratio = initial_ratio;
+
+	for (int ch = 0 ; ch < channels ; ch++)
+	{	double freq = 0.01;
+		gen_windowed_sines (1, &freq, 1.0, tmpBuffer + ch * NUM_FRAMES, NUM_FRAMES);
+	}
+	interleave_data(tmpBuffer, input, NUM_FRAMES, channels);
+
+	SRC_STATE *state;
+	int error;
+	if ((state = src_new (converter, channels, &error)) == NULL)
+	{
+		printf ("\n\nLine %d : src_new() failed : %s\n\n", __LINE__, src_strerror (error));
+		exit (1);
+	}
+
+	long input_frames = data.input_frames;
+	curData = data;
+	curData.input_frames = CHUNK_SIZE;
+
+	CHECKED_CALL(src_process (state, &curData));
+	adjustData(&data, &curData, channels);
+	input_frames -= curData.input_frames_used;
+	curData.src_ratio = second_ratio;
+	CHECKED_CALL(src_set_ratio (state, curData.src_ratio));
+	while(input_frames && curData.output_frames)
+	{
+		CHECKED_CALL(src_process (state, &curData));
+		adjustData(&data, &curData, channels);
+		input_frames -= curData.input_frames_used;
+
+		curData.input_frames =  MIN(input_frames, CHUNK_SIZE);
+		curData.end_of_input = curData.input_frames == input_frames;
+	}
+
+	TEST(data.input_frames_used > 0);
+	TEST(data.input_frames_used <= data.input_frames);
+	TEST(data.output_frames_gen > 0);
+	TEST(data.output_frames_gen <= data.output_frames);
+
+	for (long i = 0 ; i < data.output_frames_gen * channels ; i++)
+	{
+		TEST(!isnan(output[i]));
+	}
+	
+	state = src_delete (state) ;
+	free(input);
+	free(output);
+	free(tmpBuffer);
+}


### PR DESCRIPTION
As described in https://github.com/erikd/libsamplerate/issues/5#issuecomment-519166957 there is a serious bug when using a variable ratio that decreases. In the tests this results in either NaNs in the output or a crash when
accessing invalid memory (or an error when using ASAN) due to `data_index` being negative.

This gets more serious the more channels are used and the higher the ratio difference is as that makes the index more negative causing it first to point to data inside the `SINC_FILTER` struct, then in front of it (which might not even be allocated)

This adds a test for reproducing this, no fix contained so CI failure is expected