### PR TITLE
Fix an out-of-bounds read error

### DIFF
--- a/src/src_sinc.c
+++ b/src/src_sinc.c
@@ -295,12 +295,14 @@ calc_output_single (SINC_FILTER *filter, increment_t increment, increment_t star
 
 	left = 0.0 ;
 	do
-	{	fraction = fp_to_double (filter_index) ;
-		indx = fp_to_int (filter_index) ;
+	{	if (data_index >= 0) /* Avoid underflow access to filter->buffer. */
+		{	fraction = fp_to_double (filter_index) ;
+			indx = fp_to_int (filter_index) ;
 
-		icoeff = filter->coeffs [indx] + fraction * (filter->coeffs [indx + 1] - filter->coeffs [indx]) ;
+			icoeff = filter->coeffs [indx] + fraction * (filter->coeffs [indx + 1] - filter->coeffs [indx]) ;
 
-		left += icoeff * filter->buffer [data_index] ;
+			left += icoeff * filter->buffer [data_index] ;
+			}  ;
 
 		filter_index -= increment ;
 		data_index = data_index + 1 ;
@@ -440,13 +442,15 @@ calc_output_stereo (SINC_FILTER *filter, increment_t increment, increment_t star
 
 	left [0] = left [1] = 0.0 ;
 	do
-	{	fraction = fp_to_double (filter_index) ;
-		indx = fp_to_int (filter_index) ;
+	{	if (data_index >= 0) /* Avoid underflow access to filter->buffer. */
+		{	fraction = fp_to_double (filter_index) ;
+			indx = fp_to_int (filter_index) ;
 
-		icoeff = filter->coeffs [indx] + fraction * (filter->coeffs [indx + 1] - filter->coeffs [indx]) ;
+			icoeff = filter->coeffs [indx] + fraction * (filter->coeffs [indx + 1] - filter->coeffs [indx]) ;
 
-		left [0] += icoeff * filter->buffer [data_index] ;
-		left [1] += icoeff * filter->buffer [data_index + 1] ;
+			left [0] += icoeff * filter->buffer [data_index] ;
+			left [1] += icoeff * filter->buffer [data_index + 1] ;
+			} ;
 
 		filter_index -= increment ;
 		data_index = data_index + 2 ;
@@ -587,15 +591,17 @@ calc_output_quad (SINC_FILTER *filter, increment_t increment, increment_t start_
 
 	left [0] = left [1] = left [2] = left [3] = 0.0 ;
 	do
-	{	fraction = fp_to_double (filter_index) ;
-		indx = fp_to_int (filter_index) ;
+	{	if (data_index >= 0) /* Avoid underflow access to filter->buffer. */
+		{	fraction = fp_to_double (filter_index) ;
+			indx = fp_to_int (filter_index) ;
 
-		icoeff = filter->coeffs [indx] + fraction * (filter->coeffs [indx + 1] - filter->coeffs [indx]) ;
+			icoeff = filter->coeffs [indx] + fraction * (filter->coeffs [indx + 1] - filter->coeffs [indx]) ;
 
-		left [0] += icoeff * filter->buffer [data_index] ;
-		left [1] += icoeff * filter->buffer [data_index + 1] ;
-		left [2] += icoeff * filter->buffer [data_index + 2] ;
-		left [3] += icoeff * filter->buffer [data_index + 3] ;
+			left [0] += icoeff * filter->buffer [data_index] ;
+			left [1] += icoeff * filter->buffer [data_index + 1] ;
+			left [2] += icoeff * filter->buffer [data_index + 2] ;
+			left [3] += icoeff * filter->buffer [data_index + 3] ;
+			} ;
 
 		filter_index -= increment ;
 		data_index = data_index + 4 ;
@@ -740,17 +746,19 @@ calc_output_hex (SINC_FILTER *filter, increment_t increment, increment_t start_f
 
 	left [0] = left [1] = left [2] = left [3] = left [4] = left [5] = 0.0 ;
 	do
-	{	fraction = fp_to_double (filter_index) ;
-		indx = fp_to_int (filter_index) ;
+	{	if (data_index >= 0) /* Avoid underflow access to filter->buffer. */
+		{	fraction = fp_to_double (filter_index) ;
+			indx = fp_to_int (filter_index) ;
 
-		icoeff = filter->coeffs [indx] + fraction * (filter->coeffs [indx + 1] - filter->coeffs [indx]) ;
+			icoeff = filter->coeffs [indx] + fraction * (filter->coeffs [indx + 1] - filter->coeffs [indx]) ;
 
-		left [0] += icoeff * filter->buffer [data_index] ;
-		left [1] += icoeff * filter->buffer [data_index + 1] ;
-		left [2] += icoeff * filter->buffer [data_index + 2] ;
-		left [3] += icoeff * filter->buffer [data_index + 3] ;
-		left [4] += icoeff * filter->buffer [data_index + 4] ;
-		left [5] += icoeff * filter->buffer [data_index + 5] ;
+			left [0] += icoeff * filter->buffer [data_index] ;
+			left [1] += icoeff * filter->buffer [data_index + 1] ;
+			left [2] += icoeff * filter->buffer [data_index + 2] ;
+			left [3] += icoeff * filter->buffer [data_index + 3] ;
+			left [4] += icoeff * filter->buffer [data_index + 4] ;
+			left [5] += icoeff * filter->buffer [data_index + 5] ;
+			} ;
 
 		filter_index -= increment ;
 		data_index = data_index + 6 ;
@@ -910,48 +918,49 @@ calc_output_multi (SINC_FILTER *filter, increment_t increment, increment_t start
 
 		icoeff = filter->coeffs [indx] + fraction * (filter->coeffs [indx + 1] - filter->coeffs [indx]) ;
 
-		/*
-		**	Duff's Device.
-		**	See : http://en.wikipedia.org/wiki/Duff's_device
-		*/
-		ch = channels ;
-		do
-		{
-			switch (ch % 8)
-			{	default :
-					ch -- ;
-					left [ch] += icoeff * filter->buffer [data_index + ch] ;
-					/* Falls through. */
-				case 7 :
-					ch -- ;
-					left [ch] += icoeff * filter->buffer [data_index + ch] ;
-					/* Falls through. */
-				case 6 :
-					ch -- ;
-					left [ch] += icoeff * filter->buffer [data_index + ch] ;
-					/* Falls through. */
-				case 5 :
-					ch -- ;
-					left [ch] += icoeff * filter->buffer [data_index + ch] ;
-					/* Falls through. */
-				case 4 :
-					ch -- ;
-					left [ch] += icoeff * filter->buffer [data_index + ch] ;
-					/* Falls through. */
-				case 3 :
-					ch -- ;
-					left [ch] += icoeff * filter->buffer [data_index + ch] ;
-					/* Falls through. */
-				case 2 :
-					ch -- ;
-					left [ch] += icoeff * filter->buffer [data_index + ch] ;
-					/* Falls through. */
-				case 1 :
-					ch -- ;
-					left [ch] += icoeff * filter->buffer [data_index + ch] ;
-				} ;
-			}
-		while (ch > 0) ;
+		if (data_index >= 0) /* Avoid underflow access to filter->buffer. */
+		{	/*
+			**	Duff's Device.
+			**	See : http://en.wikipedia.org/wiki/Duff's_device
+			*/
+			ch = channels ;
+			do
+			{	switch (ch % 8)
+				{	default :
+						ch -- ;
+						left [ch] += icoeff * filter->buffer [data_index + ch] ;
+						/* Falls through. */
+					case 7 :
+						ch -- ;
+						left [ch] += icoeff * filter->buffer [data_index + ch] ;
+						/* Falls through. */
+					case 6 :
+						ch -- ;
+						left [ch] += icoeff * filter->buffer [data_index + ch] ;
+						/* Falls through. */
+					case 5 :
+						ch -- ;
+						left [ch] += icoeff * filter->buffer [data_index + ch] ;
+						/* Falls through. */
+					case 4 :
+						ch -- ;
+						left [ch] += icoeff * filter->buffer [data_index + ch] ;
+						/* Falls through. */
+					case 3 :
+						ch -- ;
+						left [ch] += icoeff * filter->buffer [data_index + ch] ;
+						/* Falls through. */
+					case 2 :
+						ch -- ;
+						left [ch] += icoeff * filter->buffer [data_index + ch] ;
+						/* Falls through. */
+					case 1 :
+						ch -- ;
+						left [ch] += icoeff * filter->buffer [data_index + ch] ;
+					} ;
+				}
+			while (ch > 0) ;
+			} ;
 
 		filter_index -= increment ;
 		data_index = data_index + channels ;

--- a/tests/util.h
+++ b/tests/util.h
@@ -29,6 +29,12 @@ double calculate_snr (float *data, int len, int expected_peaks) ;
 
 const char * get_cpu_name (void) ;
 
+#define ASSERT(condition) \
+	if (!(condition)) \
+	{	printf ("Condition failed on Line %d : %s\n\n", __LINE__, #condition) ; \
+		exit (1) ; \
+	    } ;
+
 #if OS_IS_WIN32
 /*
 **	Extra Win32 hacks.


### PR DESCRIPTION
The bad data that is read is audio data in floating point format that is immediately multiplied by a compile time constant value (read from a very large table of floating point values) and then added to an accumulator.

As such, this is not an exploitable bug. 