### PR TITLE
Fix buffer allocation of SINC converters

### DIFF
--- a/src/src_sinc.c
+++ b/src/src_sinc.c
@@ -212,9 +212,10 @@ sinc_set_converter (SRC_PRIVATE *psrc, int src_enum)
 	** a better way. Need to look at prepare_data () at the same time.
 	*/
 
-	temp_filter.b_len = (int) lrint (2.5 * temp_filter.coeff_half_len / (temp_filter.index_inc * 1.0) * SRC_MAX_RATIO) ;
+	temp_filter.b_len = 3 * (int) lrint ((temp_filter.coeff_half_len + 2.0) / temp_filter.index_inc * SRC_MAX_RATIO + 1) ;
 	temp_filter.b_len = MAX (temp_filter.b_len, 4096) ;
 	temp_filter.b_len *= temp_filter.channels ;
+	temp_filter.b_len += 1 ; // There is a <= check against samples_in_hand requiring a buffer bigger than the calculation above
 
 	if ((filter = ZERO_ALLOC (SINC_FILTER, sizeof (SINC_FILTER) + sizeof (filter->buffer [0]) * (temp_filter.b_len + temp_filter.channels))) == NULL)
 		return SRC_ERR_MALLOC_FAILED ;


### PR DESCRIPTION
I implemented a test case showing the usage of `src_simple` with a small ratio leading to the bug described in #92 where no output is produced no matter how much input is provided.

As requested in https://github.com/erikd/libsamplerate/pull/87#issuecomment-524617588 I traced that bug to the calculation of `b_len` and fixed that.

Assumptions:
- `prepare_data` uses correct values for `len`, `b_current` and `b_end` which due to its simplicity is very likely
- `samples_in_hand <= half_filter_chan_len` is the correct condition for which to NOT produce output data (unsure about the `<=` instead of `<` but rest looks ok)
- calculation of `half_filter_chan_len` is correct (probably, although there is a +1 which I can't understand)

Given those I derived the formula for `b_len` so that the condition `samples_in_hand > half_filter_chan_len` just holds.

With this change the tests pass.

I did not include the comparison between `src_simple` and `src_process` developed in #87 to keep this simple. I recommend adding it in a separate PR to actually verify the outputs against each other.