### PR TITLE
Fix autotools CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,10 @@ dist: xenial
 jobs:
   fast_finish: true
   include:
-    - sudo: required
-      env: USING_AUTOTOOLS=yes
-      before_install:
-        - sudo add-apt-repository ppa:ondrej/autotools -y # automake 1.15
-        - sudo add-apt-repository ppa:cz.nic-labs/knot-dns -y # pkg-config 0.29.2
-        - sudo apt-get update
-        - sudo apt-get install -y autoconf automake-1.15 pkg-config m4
+    - env: USING_AUTOTOOLS=yes
+      addons:
+        apt:
+          packages: [libsndfile-dev, libfftw3-dev, libasound2-dev,  autoconf, automake-1.15, pkg-config, m4]
       script:
         - ./autogen.sh && ./configure --enable-sndfile --enable-alsa && make distcheck
         - cat src/config.h


### PR DESCRIPTION
The autotools ppa does no longer exist:
```
Cannot add PPA: 'ppa:~ondrej/ubuntu/autotools'.
The user named '~ondrej' has no PPA named 'ubuntu/autotools'
Please choose from the following available PPAs:
 * 'apache2':  PPA for Apache 2.x
 * 'apache2-qa':  PPA for Apache2 (QA builds; experimental)
 * 'common':  Common PPA packages
 * 'nginx':  PPA for NGINX Stable with HTTP/2
 * 'nginx-mainline':  PPA for NGINX Mainline with HTTP/2
 * 'nginx-qa':  PPA for NGINX Mainline (QA builds; experimental)
 * 'php':  ***** The main PPA for supported PHP versions with many PECL extensions *****
 * 'php-qa':  PPA for PHP (QA builds; experimental)
 * 'php5-compat':  PPA with dummy compatibility php5* packages
 * 'pkg-gearman':  PPA for Gearman
 * 'sandbox':  Sandbox for preparation of various packages (DON'T USE)
```